### PR TITLE
update default archetype to use yaml

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,9 +1,7 @@
-+++
-title= "{{ replace .TranslationBaseName "-" " " | title }}"
-date= {{ .Date }}
-description = ""
-draft= true
-+++
+---
+title: {{ replace .TranslationBaseName "-" " " | title }}
+layout: post
+weight: 20
+---
 
-Lorem Ipsum.
-Notice `draft` is set to true.
+# {{ replace .TranslationBaseName "-" " " | title }}


### PR DESCRIPTION
Changes the 'default' archetype to use yaml instead of markdown. This means that we can use

```
$ hugo new editing-the-wiki/hugo/advanced-hugo.md
```

and hugo will generate the file with that name and the content:
```md
---
title: Advanced Hugo
layout: post
weight: 20
---

# Advanced Hugo
```
