### PR TITLE
Make the links in articles blue

### DIFF
--- a/static/scss/flex/article.scss
+++ b/static/scss/flex/article.scss
@@ -7,6 +7,10 @@ article {
     overflow-y: auto;
     padding: 0 4rem;
 
+    a {
+        color: #00b3e6
+    }
+
     h1:first-of-type {
         margin: 2.5rem 0rem;
         font-family: "--apple-system", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;

--- a/static/theme-flex/style.css
+++ b/static/theme-flex/style.css
@@ -282,6 +282,8 @@ article {
   margin: 0 1rem 0 20rem;
   overflow-y: auto;
   padding: 0 4rem; }
+  article a {
+    color: #00b3e6; }
   article h1:first-of-type {
     margin: 2.5rem 0rem;
     font-family: "--apple-system", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;


### PR DESCRIPTION
Right now, links in the body of articles show as the same color as surrounding text. This makes it super hard to distinguish links from normal paragraph text. 

This PR changes the link color to the flatiron blue, so they can be seen.